### PR TITLE
Fix scroll(): scroll within Radix ScrollArea

### DIFF
--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -478,7 +478,7 @@ export class Actor {
       await this.moveTo(selector);
     }
 
-    const behavior = this.mode === "human" ? "smooth" : "auto";
+    const behavior: ScrollBehavior = this.mode === "human" ? "smooth" : "auto";
 
     if (selector) {
       // The selector may point at a wrapper (e.g. Radix ScrollArea Root) rather than the


### PR DESCRIPTION
## Summary
- Fix `Actor.scroll(selector, deltaY)` to scroll the actual scrollable element when the selector points to a wrapper (Radix ScrollArea Root).
- This makes the basic-ui step `actor.scroll('[data-testid=\"scroll-area\"]', 600)` scroll the scroll area viewport instead of only moving the page.

## Test plan
- CI: GitHub Actions `ci` workflow (artifacts should include `run.mp4` + `captions.vtt`).
- Local: `pnpm b2v run --scenario basic-ui --mode human --record screencast` and verify the scroll area content moves.

Made with [Cursor](https://cursor.com)