### PR TITLE
Add interactive TUI terminal scenario with xterm.js + node-pty

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scenario: [basic-ui, collab, github, kanban]
+        scenario: [basic-ui, collab, github, kanban, tui-terminals]
         mode: [human, fast]
     steps:
       - name: Checkout
@@ -28,10 +28,10 @@ jobs:
         with:
           version: 10.29.3
 
-      - name: Install system deps (xvfb, xterm, ffmpeg)
+      - name: Install system deps (xvfb, xterm, ffmpeg, mc, htop)
         run: |
           sudo apt-get update
-          sudo apt-get install -y xvfb xterm ffmpeg
+          sudo apt-get install -y xvfb xterm ffmpeg mc htop
 
       - name: Install deps
         run: pnpm install --frozen-lockfile

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -20,7 +20,9 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.1.0",
-    "tailwind-merge": "^2.6.0"
+    "tailwind-merge": "^2.6.0",
+    "xterm": "^5.3.0",
+    "@xterm/addon-fit": "^0.10.0"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "pnpm": {
     "onlyBuiltDependencies": [
       "esbuild",
+      "node-pty",
       "puppeteer",
       "@ffmpeg-installer/darwin-arm64",
       "@ffmpeg-installer/linux-x64",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -7,9 +7,9 @@ import path from "path";
 import { fileURLToPath, pathToFileURL } from "url";
 import { createServer, type ViteDevServer } from "vite";
 import { run, runCollab, type Mode, type NarrationOptions } from "@browser2video/runner";
-import { basicUiScenario, collabScenario, githubScenario, kanbanScenario } from "@browser2video/scenarios";
+import { basicUiScenario, collabScenario, githubScenario, kanbanScenario, tuiTerminalsScenario } from "@browser2video/scenarios";
 
-type ScenarioName = "basic-ui" | "collab" | "github" | "kanban";
+type ScenarioName = "basic-ui" | "collab" | "github" | "kanban" | "tui-terminals";
 type RecordMode = "none" | "screencast" | "screen";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -102,7 +102,7 @@ program
   .command("list-scenarios")
   .description("List built-in scenarios.")
   .action(() => {
-    console.log(["basic-ui", "collab", "github", "kanban"].join("\n"));
+    console.log(["basic-ui", "collab", "github", "kanban", "tui-terminals"].join("\n"));
   });
 
 program
@@ -179,7 +179,7 @@ program
       ? (scenarioKind === "single" || scenarioKind === "collab" ? demoRoot : null)
       : scenario === "kanban"
         ? kanbanDemoRoot
-        : (scenario === "basic-ui" || scenario === "collab")
+        : (scenario === "basic-ui" || scenario === "collab" || scenario === "tui-terminals")
           ? demoRoot
           : null;
 
@@ -246,6 +246,7 @@ program
       const scenarioFn =
         scenario === "github" ? githubScenario :
         scenario === "kanban" ? kanbanScenario :
+        scenario === "tui-terminals" ? tuiTerminalsScenario :
         basicUiScenario;
       await run({
         mode,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@automerge/react':
         specifier: ^2.5.1
         version: 2.5.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@xterm/addon-fit':
+        specifier: ^0.10.0
+        version: 0.10.0(@xterm/xterm@5.5.0)
       '@xyflow/react':
         specifier: ^12.10.0
         version: 12.10.0(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -59,6 +62,9 @@ importers:
       tailwind-merge:
         specifier: ^2.6.0
         version: 2.6.1
+      xterm:
+        specifier: ^5.3.0
+        version: 5.3.0
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4.0.0
@@ -208,10 +214,19 @@ importers:
       '@browser2video/runner':
         specifier: workspace:*
         version: link:../../packages/runner
+      node-pty:
+        specifier: ^1.0.0
+        version: 1.1.0
       puppeteer:
         specifier: ^24.0.0
         version: 24.37.2(typescript@5.7.3)
+      ws:
+        specifier: ^8.18.0
+        version: 8.19.0
     devDependencies:
+      '@types/ws':
+        specifier: ^8.18.0
+        version: 8.18.1
       typescript:
         specifier: ~5.7.0
         version: 5.7.3
@@ -3494,6 +3509,14 @@ packages:
   '@webassemblyjs/wast-printer@1.14.1':
     resolution: {integrity: sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==}
 
+  '@xterm/addon-fit@0.10.0':
+    resolution: {integrity: sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==}
+    peerDependencies:
+      '@xterm/xterm': ^5.0.0
+
+  '@xterm/xterm@5.5.0':
+    resolution: {integrity: sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==}
+
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
 
@@ -5850,6 +5873,9 @@ packages:
   no-case@3.0.4:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
 
+  node-addon-api@7.1.1:
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+
   node-emoji@2.2.0:
     resolution: {integrity: sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==}
     engines: {node: '>=18'}
@@ -5857,6 +5883,9 @@ packages:
   node-gyp-build-optional-packages@5.1.1:
     resolution: {integrity: sha512-+P72GAjVAbTxjjwUmwjVrqrdZROD4nf8KgpBoDxqXXTiYZZt/ud60dE5yvCSr9lRO8e8yv6kgJIC0K0PfZFVQw==}
     hasBin: true
+
+  node-pty@1.1.0:
+    resolution: {integrity: sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==}
 
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
@@ -7644,6 +7673,10 @@ packages:
 
   xstate@5.27.0:
     resolution: {integrity: sha512-ILzEhrLTbTyh3kP19IgLBX/sOSfejnDXrxcftuXS9QaY6mc8QuHXcl3GqUIAaAXM/09/ozHFn0nGFlQj+r9tCg==}
+
+  xterm@5.3.0:
+    resolution: {integrity: sha512-8QqjlekLUFTrU6x7xck1MsPzPA571K5zNqWm0M0oroYEWVOptZ0+ubQSkQ3uxIEhcIHRujJy6emDWX4A7qyFzg==}
+    deprecated: This package is now deprecated. Move to @xterm/xterm instead.
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -11815,6 +11848,12 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@xtuc/long': 4.2.2
 
+  '@xterm/addon-fit@0.10.0(@xterm/xterm@5.5.0)':
+    dependencies:
+      '@xterm/xterm': 5.5.0
+
+  '@xterm/xterm@5.5.0': {}
+
   '@xtuc/ieee754@1.2.0': {}
 
   '@xtuc/long@4.2.2': {}
@@ -14594,6 +14633,8 @@ snapshots:
       lower-case: 2.0.2
       tslib: 2.8.1
 
+  node-addon-api@7.1.1: {}
+
   node-emoji@2.2.0:
     dependencies:
       '@sindresorhus/is': 4.6.0
@@ -14605,6 +14646,10 @@ snapshots:
     dependencies:
       detect-libc: 2.1.2
     optional: true
+
+  node-pty@1.1.0:
+    dependencies:
+      node-addon-api: 7.1.1
 
   node-releases@2.0.27: {}
 
@@ -16733,6 +16778,8 @@ snapshots:
       sax: 1.4.4
 
   xstate@5.27.0: {}
+
+  xterm@5.3.0: {}
 
   y18n@5.0.8: {}
 

--- a/tests/scenarios/index.ts
+++ b/tests/scenarios/index.ts
@@ -5,4 +5,5 @@ export { basicUiScenario } from "./scenario.js";
 export { collabScenario } from "./collab-scenario.js";
 export { githubScenario } from "./github-scenario.js";
 export { kanbanScenario } from "./kanban-scenario.js";
+export { tuiTerminalsScenario } from "./tui-terminals.js";
 

--- a/tests/scenarios/package.json
+++ b/tests/scenarios/package.json
@@ -17,9 +17,12 @@
   },
   "dependencies": {
     "@browser2video/runner": "workspace:*",
+    "node-pty": "^1.0.0",
+    "ws": "^8.18.0",
     "puppeteer": "^24.0.0"
   },
   "devDependencies": {
+    "@types/ws": "^8.18.0",
     "typescript": "~5.7.0"
   }
 }

--- a/tests/scenarios/terminal/terminal-ws-server.ts
+++ b/tests/scenarios/terminal/terminal-ws-server.ts
@@ -1,0 +1,235 @@
+/**
+ * @description WebSocket <-> PTY bridge for rendering real terminals inside xterm.js.
+ * Supports general-purpose shell sessions (/term/shell) and direct TUI launches (/term/mc, /term/htop).
+ */
+import http from "node:http";
+import fs from "node:fs";
+import path from "node:path";
+import { createRequire } from "node:module";
+import { WebSocketServer, type WebSocket } from "ws";
+import * as pty from "node-pty";
+
+export type TerminalServer = {
+  /** Base URL (without trailing slash), e.g. ws://127.0.0.1:12345 */
+  baseWsUrl: string;
+  close: () => Promise<void>;
+};
+
+type AppKind = "shell" | "mc" | "htop";
+
+function safeLocale(): string {
+  return (
+    process.env.LC_ALL ??
+    process.env.LANG ??
+    (process.platform === "darwin" ? "en_US.UTF-8" : "C.UTF-8")
+  );
+}
+
+function ensureNodePtySpawnHelperExecutable() {
+  // node-pty prebuilds ship spawn-helper without +x sometimes (macOS),
+  // which causes "posix_spawnp failed" at runtime.
+  try {
+    const require = createRequire(import.meta.url);
+    const unixTerminalPath = require.resolve("node-pty/lib/unixTerminal.js");
+    const pkgRoot = path.resolve(path.dirname(unixTerminalPath), "..");
+    const helper = path.join(
+      pkgRoot,
+      "prebuilds",
+      `${process.platform}-${process.arch}`,
+      "spawn-helper",
+    );
+
+    if (!fs.existsSync(helper)) return;
+    const st = fs.statSync(helper);
+    const isExecutable = (st.mode & 0o111) !== 0;
+    if (isExecutable) return;
+    fs.chmodSync(helper, 0o755);
+  } catch {
+    // ignore
+  }
+}
+
+function spawnPty(app: AppKind, initialCols: number, initialRows: number) {
+  const locale = safeLocale();
+  const env: Record<string, string> = {
+    ...(process.env as Record<string, string>),
+    TERM: "xterm-256color",
+    COLORTERM: "truecolor",
+    LANG: locale,
+    LC_ALL: locale,
+  };
+
+  if (app === "shell") {
+    // General-purpose interactive shell with a clean prompt for reliable detection
+    env.PS1 = "\\$ ";
+    return pty.spawn("bash", ["--norc", "--noprofile", "-i"], {
+      name: "xterm-256color",
+      cols: initialCols,
+      rows: initialRows,
+      cwd: process.cwd(),
+      env,
+    });
+  }
+
+  // Direct TUI launch (mc / htop)
+  const script =
+    app === "mc"
+      ? "command -v mc >/dev/null 2>&1 || { echo __B2V_MISSING_MC__; exit 127; }; mc; echo __B2V_MC_EXITED__"
+      : "command -v htop >/dev/null 2>&1 || { echo __B2V_MISSING_HTOP__; exit 127; }; htop; echo __B2V_HTOP_EXITED__";
+
+  return pty.spawn("bash", ["-lc", script], {
+    name: "xterm-256color",
+    cols: initialCols,
+    rows: initialRows,
+    cwd: process.cwd(),
+    env,
+  });
+}
+
+function isResizeMessage(v: unknown): v is { type: "resize"; cols: number; rows: number } {
+  const obj = v as any;
+  return (
+    obj &&
+    typeof obj === "object" &&
+    obj.type === "resize" &&
+    Number.isFinite(obj.cols) &&
+    Number.isFinite(obj.rows)
+  );
+}
+
+export async function startTerminalWsServer(): Promise<TerminalServer> {
+  ensureNodePtySpawnHelperExecutable();
+
+  const server = http.createServer((_req, res) => {
+    res.statusCode = 404;
+    res.setHeader("content-type", "text/plain; charset=utf-8");
+    res.end("Not found");
+  });
+
+  const wss = new WebSocketServer({ noServer: true });
+  const encoder = new TextEncoder();
+  const decoder = new TextDecoder("utf-8");
+
+  function handleTerminalWs(ws: WebSocket, app: AppKind) {
+    try {
+      ws.send(encoder.encode(`[b2v] connected: ${app}\r\n`));
+    } catch {
+      // ignore
+    }
+
+    // Default size; client will immediately send resize after fit.
+    const p = spawnPty(app, 120, 30);
+
+    p.onData((data: string) => {
+      try {
+        ws.send(encoder.encode(data));
+      } catch {
+        // ignore send errors during teardown
+      }
+    });
+
+    ws.on("message", (msg: any, isBinary?: boolean) => {
+      try {
+        // In Node/ws, string messages often arrive as Buffer with isBinary=false.
+        if (isBinary === false) {
+          const text =
+            typeof msg === "string"
+              ? msg
+              : Buffer.isBuffer(msg)
+                ? msg.toString("utf8")
+                : ArrayBuffer.isView(msg)
+                  ? Buffer.from(msg.buffer, msg.byteOffset, msg.byteLength).toString("utf8")
+                  : msg instanceof ArrayBuffer
+                    ? Buffer.from(msg).toString("utf8")
+                    : "";
+          if (!text) return;
+          const parsed = JSON.parse(text);
+          if (isResizeMessage(parsed)) {
+            p.resize(parsed.cols, parsed.rows);
+          }
+          return;
+        }
+
+        // Binary stdin (xterm onData)
+        if (msg instanceof ArrayBuffer) {
+          p.write(decoder.decode(new Uint8Array(msg)));
+          return;
+        }
+
+        // ws on Node typically delivers Buffer
+        if (Buffer.isBuffer(msg)) {
+          p.write(decoder.decode(msg));
+          return;
+        }
+
+        if (ArrayBuffer.isView(msg)) {
+          p.write(decoder.decode(new Uint8Array(msg.buffer, msg.byteOffset, msg.byteLength)));
+        }
+      } catch {
+        // ignore malformed input
+      }
+    });
+
+    ws.on("close", () => {
+      try {
+        p.kill();
+      } catch {
+        // ignore
+      }
+    });
+
+    ws.on("error", () => {
+      try {
+        p.kill();
+      } catch {
+        // ignore
+      }
+    });
+  }
+
+  server.on("upgrade", (req, socket, head) => {
+    try {
+      const u = new URL(req.url ?? "/", "http://localhost");
+      const pathname = u.pathname;
+
+      let app: AppKind | null = null;
+      if (pathname === "/term/shell") app = "shell";
+      if (pathname === "/term/mc") app = "mc";
+      if (pathname === "/term/htop") app = "htop";
+      if (!app) {
+        socket.destroy();
+        return;
+      }
+
+      wss.handleUpgrade(req, socket, head, (ws) => {
+        wss.emit("connection", ws, req);
+        handleTerminalWs(ws, app);
+      });
+    } catch {
+      socket.destroy();
+    }
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const addr = server.address();
+  if (!addr || typeof addr === "string") {
+    throw new Error("Failed to bind terminal WS server");
+  }
+
+  const baseWsUrl = `ws://localhost:${addr.port}`;
+
+  return {
+    baseWsUrl,
+    close: async () => {
+      for (const client of wss.clients) {
+        try {
+          client.close();
+        } catch {
+          // ignore
+        }
+      }
+      await new Promise<void>((resolve) => wss.close(() => resolve()));
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    },
+  };
+}

--- a/tests/scenarios/tsconfig.json
+++ b/tests/scenarios/tsconfig.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "noEmit": true
   },
-  "include": ["*.ts"]
+  "include": ["**/*.ts"]
 }
 

--- a/tests/scenarios/tui-terminals.ts
+++ b/tests/scenarios/tui-terminals.ts
@@ -1,0 +1,236 @@
+/**
+ * @description Scenario showing interactive shell terminals with TUI apps (htop, mc)
+ * running inside in-browser xterm panes connected to real PTYs.
+ * Demonstrates keyboard and mouse interaction within TUIs.
+ * htop runs in Terminal 2 while mc is used in Terminal 1 — both visible simultaneously.
+ */
+import type { ScenarioContext } from "@browser2video/runner";
+import { startTerminalWsServer } from "./terminal/terminal-ws-server.js";
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Focus xterm.js terminal and verify the textarea received focus.
+ */
+async function focusTerminal(page: any, testId: string) {
+  const selector = `[data-testid="${testId}"] .xterm-helper-textarea`;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    await page.evaluate((sel: string) => {
+      const ta = document.querySelector(sel) as HTMLElement | null;
+      ta?.focus();
+    }, selector);
+    await sleep(150);
+    const ok = await page.evaluate(
+      (sel: string) => document.activeElement === document.querySelector(sel),
+      selector,
+    );
+    if (ok) return;
+  }
+}
+
+/**
+ * Type text into a terminal. Focuses the textarea element handle directly
+ * to ensure keystrokes reach the correct terminal.
+ */
+async function typeInTerminal(page: any, testId: string, text: string, opts?: { delay?: number }) {
+  const selector = `[data-testid="${testId}"] .xterm-helper-textarea`;
+  const el = await page.$(selector);
+  if (!el) throw new Error(`Terminal textarea not found: ${selector}`);
+  await el.focus();
+  await sleep(100);
+  for (const ch of text) {
+    if (ch === "\n") {
+      await page.keyboard.press("Enter");
+    } else {
+      await page.keyboard.type(ch, { delay: 0 });
+    }
+    if (opts?.delay) await sleep(opts.delay);
+  }
+}
+
+/** Wait until the XtermPane WebSocket transitions to "open". */
+async function waitForWsOpen(page: any, selector: string, timeoutMs = 15000) {
+  await page.waitForFunction(
+    (sel: string) => {
+      const el = document.querySelector(sel) as any;
+      return String(el?.dataset?.b2vWsState ?? "") === "open";
+    },
+    { timeout: timeoutMs },
+    selector,
+  );
+}
+
+/** Wait until the xterm rows contain ALL of the given substrings. */
+async function waitForXtermText(page: any, rootSelector: string, includes: string[], timeoutMs: number) {
+  await page.waitForFunction(
+    (sel: string, inc: string[]) => {
+      const root = document.querySelector(sel);
+      if (!root) return false;
+      const rows = root.querySelector(".xterm-rows");
+      const text = String((rows as any)?.textContent ?? (root as any)?.textContent ?? "");
+      return inc.every((s) => text.includes(s));
+    },
+    { timeout: timeoutMs },
+    rootSelector,
+    includes,
+  );
+}
+
+/** Wait for shell prompt ($ ) to appear. */
+async function waitForPrompt(page: any, testId: string, timeoutMs = 15000) {
+  await waitForXtermText(page, `[data-testid="${testId}"]`, ["$"], timeoutMs);
+}
+
+/**
+ * Click at a relative position inside a terminal with visible cursor animation.
+ * Uses the actor's cursor overlay (__b2v_moveCursor / __b2v_clickEffect) so
+ * the mouse movement and click are visible in the recorded video.
+ */
+async function clickInTerminal(page: any, testId: string, relX: number, relY: number) {
+  const box = await page.$eval(`[data-testid="${testId}"]`, (el: any) => {
+    const r = el.getBoundingClientRect();
+    return { x: r.x, y: r.y, width: r.width, height: r.height };
+  });
+
+  const targetX = Math.round(box.x + box.width * relX);
+  const targetY = Math.round(box.y + box.height * relY);
+
+  // Read current cursor position from the overlay element
+  const startPos = await page.evaluate(() => {
+    const cursor = document.getElementById("__b2v_cursor");
+    if (!cursor) return null;
+    const m = cursor.style.transform.match(/translate\((.+?)px,\s*(.+?)px\)/);
+    if (m) return { x: parseFloat(m[1]) + 2, y: parseFloat(m[2]) + 2 };
+    return null;
+  });
+
+  const fromX = startPos?.x ?? targetX - 80;
+  const fromY = startPos?.y ?? targetY - 40;
+
+  // Animate cursor movement with ease-out cubic (visible in recording)
+  const steps = 25;
+  for (let i = 0; i <= steps; i++) {
+    const t = i / steps;
+    const ease = 1 - Math.pow(1 - t, 3);
+    const px = Math.round(fromX + (targetX - fromX) * ease);
+    const py = Math.round(fromY + (targetY - fromY) * ease);
+    await page.mouse.move(px, py);
+    await page.evaluate(`window.__b2v_moveCursor?.(${px}, ${py})`);
+    if (i < steps) await sleep(8);
+  }
+
+  // Click ripple effect
+  await page.evaluate(`window.__b2v_clickEffect?.(${targetX}, ${targetY})`);
+  await sleep(40);
+
+  // Press-and-release
+  await page.mouse.down();
+  await sleep(80);
+  await page.mouse.up();
+  await sleep(60);
+}
+
+export async function tuiTerminalsScenario(ctx: ScenarioContext) {
+  const { step, actor, page, baseURL } = ctx;
+  const srv = await startTerminalWsServer();
+
+  try {
+    await step("Open notes with terminals", async () => {
+      const url = `${baseURL}/notes?termWs=${encodeURIComponent(srv.baseWsUrl)}`;
+      await actor.goto(url);
+      await actor.waitFor('[data-testid="notes-page"]');
+      await actor.waitFor('[data-testid="xterm-term1"] .xterm');
+      await actor.waitFor('[data-testid="xterm-term2"] .xterm');
+    });
+
+    await step("Wait for terminal connections", async () => {
+      await waitForWsOpen(page, '[data-testid="xterm-term1"]');
+      await waitForWsOpen(page, '[data-testid="xterm-term2"]');
+    });
+
+    await step("Wait for shell prompts", async () => {
+      await waitForPrompt(page, "xterm-term1");
+      await waitForPrompt(page, "xterm-term2");
+    });
+
+    // --- Launch htop in Terminal 2 (stays running throughout) ---
+
+    await step("Run htop in Terminal 2", async () => {
+      await typeInTerminal(page, "xterm-term2", "htop\n", { delay: 60 });
+      await waitForXtermText(page, '[data-testid="xterm-term2"]', ["CPU"], 20000);
+      await sleep(1000);
+    });
+
+    // --- Launch mc in Terminal 1 (htop keeps running in Terminal 2) ---
+
+    await step("Run mc in Terminal 1", async () => {
+      await typeInTerminal(page, "xterm-term1", "mc\n", { delay: 60 });
+      await waitForXtermText(page, '[data-testid="xterm-term1"]', ["1Help"], 20000);
+      await sleep(800);
+    });
+
+    await step("Navigate mc with keyboard", async () => {
+      await focusTerminal(page, "xterm-term1");
+      for (let i = 0; i < 3; i++) {
+        await page.keyboard.press("ArrowDown");
+        await sleep(300);
+      }
+      await page.keyboard.press("ArrowUp");
+      await sleep(300);
+    });
+
+    await step("Click files in left panel", async () => {
+      await focusTerminal(page, "xterm-term1");
+      await clickInTerminal(page, "xterm-term1", 0.20, 0.14);
+      await sleep(400);
+      await clickInTerminal(page, "xterm-term1", 0.20, 0.22);
+      await sleep(400);
+      await clickInTerminal(page, "xterm-term1", 0.20, 0.30);
+      await sleep(400);
+      await clickInTerminal(page, "xterm-term1", 0.20, 0.18);
+      await sleep(400);
+    });
+
+    await step("Click files in right panel", async () => {
+      await clickInTerminal(page, "xterm-term1", 0.70, 0.14);
+      await sleep(400);
+      await clickInTerminal(page, "xterm-term1", 0.70, 0.22);
+      await sleep(400);
+      await clickInTerminal(page, "xterm-term1", 0.70, 0.30);
+      await sleep(400);
+    });
+
+    await step("Open directory with Enter", async () => {
+      await clickInTerminal(page, "xterm-term1", 0.70, 0.10);
+      await sleep(300);
+      await page.keyboard.press("Enter");
+      await sleep(800);
+    });
+
+    await step("Click back to left panel", async () => {
+      await clickInTerminal(page, "xterm-term1", 0.20, 0.18);
+      await sleep(400);
+      await page.keyboard.press("ArrowDown");
+      await sleep(300);
+      await page.keyboard.press("ArrowDown");
+      await sleep(300);
+    });
+
+    // --- Quit both TUIs ---
+
+    await step("Quit mc", async () => {
+      await focusTerminal(page, "xterm-term1");
+      await page.keyboard.press("F10");
+      await sleep(500);
+      await page.keyboard.press("Enter");
+      await waitForPrompt(page, "xterm-term1", 10000);
+    });
+
+    await step("Quit htop", async () => {
+      await typeInTerminal(page, "xterm-term2", "q");
+      await waitForPrompt(page, "xterm-term2", 10000);
+    });
+  } finally {
+    await srv.close();
+  }
+}


### PR DESCRIPTION
## Summary

- **New `tui-terminals` scenario**: Demonstrates real shell sessions in the browser via xterm.js connected to node-pty over WebSockets. Runs `htop` and `mc` simultaneously in separate terminal panes, navigates mc with both keyboard and animated mouse clicks (visible cursor overlay), and produces a video recording of the full interaction.
- **XtermPane component**: Added to the demo app's notes page — renders xterm.js terminals with WebSocket-backed PTY sessions, including a focus-guard that prevents accidental TUI exits on first click.
- **Terminal WebSocket server**: Node.js bridge (`terminal-ws-server.ts`) connecting browser xterm.js instances to `node-pty` processes. Supports general-purpose shells (`/term/shell`) and direct TUI launches (`/term/mc`, `/term/htop`).
- **CI updated**: Added `tui-terminals` to the scenario matrix and installs `mc`/`htop` on Ubuntu runners.

## Test plan

- [x] `tui-terminals` scenario runs locally in `human` mode with `--record screencast` — all 12 steps pass
- [x] Video recording produced showing htop + mc running side-by-side with visible mouse cursor
- [ ] CI passes for all scenarios including `tui-terminals` in both `human` and `fast` modes


Made with [Cursor](https://cursor.com)