### PR TITLE
Add terminal grid layout, fix sizing and mc interaction reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ const session = await createSession({
 | `record` | `boolean` | auto | Enable video recording |
 | `outputDir` | `string` | auto | Artifacts output directory |
 | `headed` | `boolean` | auto | Show browser window |
-| `layout` | `"auto"` \| `"row"` \| `"grid"` | `"row"` | Multi-pane layout |
+| `layout` | `"auto"` \| `"row"` \| `"column"` \| `"grid"` \| `{ cols: N }` | `"auto"` | Multi-pane layout (auto = grid) |
 | `delays` | `Partial<ActorDelays>` | - | Override actor timing |
 | `ffmpegPath` | `string` | `"ffmpeg"` | Path to ffmpeg binary |
 | `narration` | `NarrationOptions` | - | TTS narration config |
@@ -302,6 +302,7 @@ Stop recording, compose video, mix narration audio, generate subtitles, and run 
 ```ts
 const result = await session.finish();
 // result.video     — path to MP4
+// result.thumbnail — path to PNG (last-frame screenshot)
 // result.subtitles — path to WebVTT
 // result.metadata  — path to JSON
 // result.durationMs

--- a/SKILL.md
+++ b/SKILL.md
@@ -177,7 +177,7 @@ Export accumulated steps as a standalone `.ts` scenario file.
 
 End session, compose video, return artifact paths.
 
-**Returns:** `videoPath`, `subtitlesPath`, `metadataPath`, `artifactDir`, `durationMs`.
+**Returns:** `videoPath`, `thumbnailPath`, `subtitlesPath`, `metadataPath`, `artifactDir`, `durationMs`.
 
 ### b2v_status
 

--- a/packages/browser2video/actor.ts
+++ b/packages/browser2video/actor.ts
@@ -279,7 +279,7 @@ export class Actor {
   mode: Mode;
   private cursorX = 0;
   private cursorY = 0;
-  private delays: ActorDelays;
+  protected delays: ActorDelays;
 
   constructor(
     page: Page,

--- a/packages/browser2video/schemas/common.ts
+++ b/packages/browser2video/schemas/common.ts
@@ -41,10 +41,12 @@ export const ActorDelaysSchema = z.object({
 export type ActorDelays = z.infer<typeof ActorDelaysSchema>;
 
 export const LayoutConfigSchema = z.union([
-  z.literal("auto").describe("Automatically choose layout based on pane count."),
-  z.literal("row").describe("Side-by-side horizontal layout."),
-  z.literal("grid").describe("Grid layout."),
+  z.literal("auto").describe("Automatically choose grid layout based on pane count (2 cols for 2-4, ceil(sqrt(n)) for 5+)."),
+  z.literal("row").describe("Side-by-side horizontal layout (hstack)."),
+  z.literal("column").describe("Vertical stacked layout (vstack)."),
+  z.literal("grid").describe("Grid layout with auto-calculated columns."),
   z.object({ cols: z.number().int().positive().describe("Number of columns in a custom grid.") }),
+  z.array(z.array(z.number().int().min(0))).describe("Grid template: 2D array of pane indices. Repeated indices create spans."),
 ]).describe("Layout for multi-pane video composition.");
 
 export type LayoutConfig = z.infer<typeof LayoutConfigSchema>;

--- a/packages/browser2video/schemas/session.ts
+++ b/packages/browser2video/schemas/session.ts
@@ -10,7 +10,7 @@ export const SessionOptionsSchema = z.object({
   record: z.boolean().optional().describe("Enable video recording. Default: false under Playwright, true otherwise."),
   outputDir: z.string().optional().describe("Output directory for video/subtitles/metadata. Default: auto-generated."),
   headed: z.boolean().optional().describe("Force headed/headless browser. Default: headed in human, headless in fast."),
-  layout: LayoutConfigSchema.optional().describe("Layout for multi-pane video composition. Default: 'row'."),
+  layout: LayoutConfigSchema.optional().describe("Layout for multi-pane video composition. Default: 'auto' (grid)."),
   delays: ActorDelaysSchema.partial().optional().describe("Override actor timing delays."),
   ffmpegPath: z.string().optional().describe("Path to ffmpeg binary. Default: 'ffmpeg'."),
   screenIndex: z.number().int().optional().describe("macOS screen index for screen recording."),
@@ -50,6 +50,7 @@ export type StepRecord = z.infer<typeof StepRecordSchema>;
 
 export const SessionResultSchema = z.object({
   video: z.string().optional().describe("Path to the composed video (undefined if recording was off)."),
+  thumbnail: z.string().optional().describe("Path to the video thumbnail PNG (last frame screenshot)."),
   subtitles: z.string().describe("Path to the WebVTT subtitles file."),
   metadata: z.string().describe("Path to the JSON metadata file."),
   artifactDir: z.string().describe("Output directory containing all artifacts."),

--- a/packages/browser2video/video-compositor.ts
+++ b/packages/browser2video/video-compositor.ts
@@ -1,6 +1,6 @@
 /**
  * @description Generalized N-pane video composition using ffmpeg.
- * Supports row (hstack), grid (xstack), and auto layouts.
+ * Supports row (hstack), column (vstack), grid (xstack), and auto layouts.
  */
 import { execFileSync, spawnSync } from "child_process";
 import { probeDurationSeconds } from "./screen-capture.ts";
@@ -10,10 +10,15 @@ import { probeDurationSeconds } from "./screen-capture.ts";
 // ---------------------------------------------------------------------------
 
 function probeWidth(videoPath: string, ffmpeg: string): number {
+  const size = probeSize(videoPath, ffmpeg);
+  return size.w;
+}
+
+function probeSize(videoPath: string, ffmpeg: string): { w: number; h: number } {
   const res = spawnSync(ffmpeg, ["-i", videoPath], { encoding: "utf-8" });
   const text = String(res.stderr ?? "") + String(res.stdout ?? "");
   const match = text.match(/Stream.*Video:.* (\d{3,5})x(\d{3,5})/);
-  return match ? parseInt(match[1], 10) : 0;
+  return match ? { w: parseInt(match[1], 10), h: parseInt(match[2], 10) } : { w: 0, h: 0 };
 }
 
 export interface ComposeOptions {
@@ -22,7 +27,7 @@ export interface ComposeOptions {
   outputPath: string;
   ffmpeg: string;
   /** Layout mode (default: "auto"). */
-  layout?: "auto" | "row" | "grid" | { cols: number };
+  layout?: "auto" | "row" | "column" | "grid" | { cols: number } | number[][];
   /** Target duration in seconds (for PTS normalisation). */
   targetDurationSec?: number;
   /** Optional CSS crop rectangle (used with cssViewportW). */
@@ -39,8 +44,8 @@ export interface ComposeOptions {
 /**
  * Compose N video files into a single video.
  * - 1 input: simple re-encode (WebM → MP4).
- * - 2-3 inputs (row / auto): hstack.
- * - 4+ inputs (grid / auto): xstack with calculated layout.
+ * - 2+ inputs (auto): grid with ceil(sqrt(n)) columns.
+ * - row: hstack, column: vstack, grid: xstack.
  */
 export function composeVideos(opts: ComposeOptions): void {
   const { inputs, outputPath, ffmpeg } = opts;
@@ -49,16 +54,20 @@ export function composeVideos(opts: ComposeOptions): void {
   if (inputs.length === 0) throw new Error("composeVideos: no inputs");
 
   // Single input: just re-encode to MP4
-  if (inputs.length === 1) {
+  if (inputs.length === 1 && !Array.isArray(layout)) {
     reencodeToMp4(inputs[0], outputPath, ffmpeg);
     return;
   }
 
+  // Grid template layout: 2D array of pane indices with optional spanning
+  if (Array.isArray(layout)) {
+    composeWithGridTemplate(inputs, outputPath, ffmpeg, layout, opts);
+    return;
+  }
+
   // Determine effective layout
-  const effectiveLayout: "row" | "grid" | { cols: number } =
-    layout === "auto"
-      ? (inputs.length <= 3 ? "row" : "grid")
-      : layout;
+  const effectiveLayout: "row" | "column" | "grid" | { cols: number } =
+    layout === "auto" ? "grid" : layout;
 
   // Build crop filter string (if cssCrop is set)
   let cropFilter = "";
@@ -93,6 +102,8 @@ export function composeVideos(opts: ComposeOptions): void {
   let stackFilter: string;
   if (effectiveLayout === "row") {
     stackFilter = `${streamLabels.join("")}hstack=inputs=${inputs.length}:shortest=1[v]`;
+  } else if (effectiveLayout === "column") {
+    stackFilter = `${streamLabels.join("")}vstack=inputs=${inputs.length}:shortest=1[v]`;
   } else {
     const cols = typeof effectiveLayout === "object" ? effectiveLayout.cols : Math.ceil(Math.sqrt(inputs.length));
     stackFilter = buildXstackFilter(streamLabels, cols);
@@ -140,13 +151,13 @@ export function composeVideos(opts: ComposeOptions): void {
   if (outDur > 0) console.error(`  Output duration: ${outDur.toFixed(2)}s`);
 }
 
-/** Re-encode a single WebM to MP4 at constant 30fps for smooth playback. */
+/** Re-encode a single WebM to MP4 at constant 60fps for smooth playback. */
 function reencodeToMp4(inputPath: string, outputPath: string, ffmpeg: string): void {
   const args = [
     "-y",
     "-i", inputPath,
-    "-vf", "fps=30,format=yuv420p",
-    "-r", "30",
+    "-vf", "fps=60,format=yuv420p",
+    "-r", "60",
     "-fps_mode", "cfr",
     "-c:v", "libx264",
     "-preset", "veryfast",
@@ -171,6 +182,149 @@ function reencodeToMp4(inputPath: string, outputPath: string, ffmpeg: string): v
       throw err;
     }
   }
+}
+
+// ---------------------------------------------------------------------------
+//  Grid template layout (2D pane-index array with optional spanning)
+// ---------------------------------------------------------------------------
+
+/**
+ * Compose videos using a grid template layout.
+ * The grid is a 2D array of pane indices. When a pane appears in multiple
+ * cells, it spans those cells and is scaled to fill the merged area.
+ *
+ * Example: `[[0, 2], [1, 2]]` — pane 2 spans the right column.
+ */
+function composeWithGridTemplate(
+  inputs: string[],
+  outputPath: string,
+  ffmpeg: string,
+  grid: number[][],
+  opts: ComposeOptions,
+): void {
+  const gridRows = grid.length;
+  const gridCols = Math.max(...grid.map((r) => r.length));
+
+  // Probe first input to determine cell dimensions
+  const cellSize = probeSize(inputs[0], ffmpeg);
+  if (cellSize.w === 0 || cellSize.h === 0) {
+    throw new Error("composeWithGridTemplate: could not probe input dimensions");
+  }
+  const cellW = cellSize.w;
+  const cellH = cellSize.h;
+
+  // Find bounding box for each unique pane index
+  const paneBoxes = new Map<number, { minRow: number; maxRow: number; minCol: number; maxCol: number }>();
+  for (let r = 0; r < gridRows; r++) {
+    for (let c = 0; c < grid[r].length; c++) {
+      const idx = grid[r][c];
+      const box = paneBoxes.get(idx);
+      if (!box) {
+        paneBoxes.set(idx, { minRow: r, maxRow: r, minCol: c, maxCol: c });
+      } else {
+        box.minRow = Math.min(box.minRow, r);
+        box.maxRow = Math.max(box.maxRow, r);
+        box.minCol = Math.min(box.minCol, c);
+        box.maxCol = Math.max(box.maxCol, c);
+      }
+    }
+  }
+
+  // Sort pane indices to build deterministic filter chains
+  const paneIndices = [...paneBoxes.keys()].sort((a, b) => a - b);
+
+  // Build crop filter string (if cssCrop is set)
+  let cropFilter = "";
+  if (opts.cssCrop) {
+    const cssVp = opts.cssViewportW ?? 1280;
+    const scale = cellW > 0 ? Math.round(cellW / cssVp) : 1;
+    const cr = {
+      x: opts.cssCrop.x * scale,
+      y: opts.cssCrop.y * scale,
+      w: opts.cssCrop.w * scale,
+      h: opts.cssCrop.h * scale,
+    };
+    cropFilter = `,crop=${cr.w}:${cr.h}:${cr.x}:${cr.y}`;
+  }
+
+  // Build per-input filter chains with optional scaling for spanning panes
+  const streamLabels: string[] = [];
+  const filterParts: string[] = [];
+
+  for (const idx of paneIndices) {
+    if (idx >= inputs.length) continue;
+    const box = paneBoxes.get(idx)!;
+    const spanCols = box.maxCol - box.minCol + 1;
+    const spanRows = box.maxRow - box.minRow + 1;
+    const targetW = spanCols * cellW;
+    const targetH = spanRows * cellH;
+    const needsScale = spanCols > 1 || spanRows > 1;
+
+    const label = `s${idx}`;
+    streamLabels.push(`[${label}]`);
+
+    const offsetMs = opts.startOffsets?.[idx] ?? 0;
+    const tpadFilter = offsetMs > 0 ? `tpad=start_duration=${offsetMs}ms,` : "";
+    const scaleFilter = needsScale ? `,scale=${targetW}:${targetH}` : "";
+
+    filterParts.push(
+      `[${idx}:v]${tpadFilter}setpts=PTS-STARTPTS,fps=60${cropFilter}${scaleFilter}[${label}]`,
+    );
+  }
+
+  // Build xstack layout with absolute pixel coordinates
+  const layoutParts: string[] = [];
+  for (const idx of paneIndices) {
+    if (idx >= inputs.length) continue;
+    const box = paneBoxes.get(idx)!;
+    const x = box.minCol * cellW;
+    const y = box.minRow * cellH;
+    layoutParts.push(`${x}_${y}`);
+  }
+
+  const activeCount = paneIndices.filter((idx) => idx < inputs.length).length;
+  const stackFilter = `${streamLabels.join("")}xstack=inputs=${activeCount}:layout=${layoutParts.join("|")}:shortest=1[v]`;
+  filterParts.push(stackFilter);
+
+  const filterComplex = filterParts.join(";");
+
+  // Build ffmpeg args
+  const args: string[] = ["-y"];
+  for (const idx of paneIndices) {
+    if (idx >= inputs.length) continue;
+    args.push("-i", inputs[idx]);
+  }
+  args.push(
+    "-filter_complex", filterComplex,
+    "-map", "[v]",
+    "-r", "60",
+    "-fps_mode", "cfr",
+    "-c:v", "libx264",
+    "-preset", "veryfast",
+    "-crf", "18",
+    "-pix_fmt", "yuv420p",
+    "-movflags", "+faststart",
+    outputPath,
+  );
+
+  try {
+    execFileSync(ffmpeg, args, { stdio: "pipe" });
+  } catch (err: any) {
+    const stderr: string = err?.stderr ?? "";
+    if (stderr.includes("fps_mode") && (stderr.includes("Unrecognized option") || stderr.includes("Option not found"))) {
+      const fallbackArgs = args.filter((a) => a !== "-fps_mode" && a !== "cfr");
+      const rIdx = fallbackArgs.findIndex((a) => a === "-r");
+      if (rIdx >= 0) {
+        fallbackArgs.splice(rIdx + 2, 0, "-vsync", "cfr");
+      }
+      execFileSync(ffmpeg, fallbackArgs, { stdio: "pipe" });
+    } else {
+      throw err;
+    }
+  }
+
+  const outDur = probeDurationSeconds(outputPath, ffmpeg);
+  if (outDur > 0) console.error(`  Output duration: ${outDur.toFixed(2)}s`);
 }
 
 /**

--- a/tests/scenarios/collab.test.ts
+++ b/tests/scenarios/collab.test.ts
@@ -12,7 +12,7 @@ async function scenario() {
   if (!server) throw new Error("Failed to start Vite server");
 
   const sync = await startSyncServer({ artifactDir: path.resolve("artifacts", "collab-sync") });
-  const session = await createSession({ layout: "row" });
+  const session = await createSession({ layout: "row" }); // 3 panes in a single row
   session.addCleanup(() => sync.stop());
   session.addCleanup(() => server.stop());
 


### PR DESCRIPTION
## Summary

- **Terminal grid layout**: New `session.createTerminalGrid()` API that renders multiple terminals in a CSS grid with iframe-based isolation. Includes grid page builder, extended video compositor, and iframe-aware `TerminalActor` focus management.
- **FitAddon fix for headless Chromium**: xterm.js FitAddon silently fails in headless mode because the render service never initializes. Added manual cell measurement fallback (reads actual xterm row height + test span for char width) that bypasses FitAddon entirely. Also fixed PTY initial size (80x24 matching xterm.js defaults) and resize timing (only after WebSocket is established).
- **Terminal improvements**: Dynamic shell title tracking via bash `PROMPT_COMMAND`/`DEBUG` trap, CSS `height: 100%` for iframe sizing, keyboard-only mc navigation replacing fragile coordinate-based clicks.

## Test plan

- [x] Fast mode: `tui-terminals.test.ts` passes consistently (3/3 runs)
- [x] Human mode: `tui-terminals.test.ts` passes
- [x] Single-actor scenarios unaffected: `basic-ui.test.ts`, `console-logs.test.ts` pass
- [x] Shell terminal fills full grid height (verified via DOM inspection: 40 rows in 696px container)
- [x] MC content consistent between fast and human modes
- [x] Terminal titles update dynamically (shell shows "vim" while running, resets to "Shell")


Made with [Cursor](https://cursor.com)